### PR TITLE
Add Voltage display on Config Page.

### DIFF
--- a/Arduino/RP2040_OOK48_LCD/DEFINES.h
+++ b/Arduino/RP2040_OOK48_LCD/DEFINES.h
@@ -72,6 +72,8 @@
 #define SAMPLERATE 9216                                         //9216 samples per second with 1024 bins gives 9Hz sample rate and 9Hz bins. 
 #define OVERSAMPLERATE SAMPLERATE * OVERSAMPLE         
 
+#define BATCAL 587.0                                            //default battery calibration value. (can be reset in config menu)
+
 #define STARTFREQ 495                                          //first frequency of interest (to nearest 9 Hz)
 #define STARTBIN 55                                            // equivalent bin number from 512 FFT bins 
 #define ENDFREQ 1098                                           //last frequency of interest (to nearest 9 Hz)

--- a/Arduino/RP2040_OOK48_LCD/DMA.ino
+++ b/Arduino/RP2040_OOK48_LCD/DMA.ino
@@ -17,10 +17,21 @@ void dma_stop(void)
     dma_channel_set_irq0_enabled(dma_chan, true);                       //re-enable interrupts                                 
 }
 
+void dma_halt(void)
+{
+    adc_run(false);
+    dma_channel_set_irq0_enabled(dma_chan, false);                      //disable DMA interrupts
+    dma_channel_abort(dma_chan);                                        //stop the DMA
+    dma_hw->ints0 = 1u << dma_chan;                                     //clear any spurious IRQ 
+    dma_channel_unclaim(dma_chan);   
+}
+
+
 //Initialise and start ADC and DMA transfers. 
 void dma_init(void)
 {
     adc_gpio_init(26 + ADC_CHAN);                                //Assign GPIO Pin to ADC for audio input
+    adc_gpio_init(26 + ADC_VOLTS);                                //Assign GPIO Pin to ADC for audio input
     adc_init();                                                  //initialise the ADC hardware
     adc_select_input(ADC_CHAN);                                  //select the Analogue input channel.
     adc_fifo_setup(true,true,1,false,false);                     //Enable ADC FIFO. Raise DRQ when 1 conversion is available. No Error bit and no bit shifting. 

--- a/Arduino/RP2040_OOK48_LCD/GUI.ino
+++ b/Arduino/RP2040_OOK48_LCD/GUI.ino
@@ -400,6 +400,7 @@ void processTouch(void)
          digitalWrite(KEYPIN, 0);
          digitalWrite(TXPIN, 0);
          cancel_repeating_timer(&TxIntervalTimer);
+         tft.setFreeFont(BUTLABEL_FONT);
          BUTkey[5].drawButton(0,"Tx");
          BUTkey[4].drawButton(0,"Set Tx");
          clearSpectrum();

--- a/Arduino/RP2040_OOK48_LCD/GUI.ino
+++ b/Arduino/RP2040_OOK48_LCD/GUI.ino
@@ -327,7 +327,10 @@ void processTouch(void)
       mode = RX;
       digitalWrite(KEYPIN, 0);
       digitalWrite(TXPIN, 0);
+      adc_select_input(ADC_VOLTS);                                  //select the Battery input channel.
       configPage();
+      waterRow = 0;
+      adc_select_input(ADC_CHAN);                                  //return to normal input channel.
       saveSettings();
       homeScreen();
       break;

--- a/Arduino/RP2040_OOK48_LCD/RP2040_OOK48_LCD.ino
+++ b/Arduino/RP2040_OOK48_LCD/RP2040_OOK48_LCD.ino
@@ -399,6 +399,11 @@ void loadSettings(void)
     ss = true;
    }
 
+  if((settings.batcal < 300) | (settings.batcal > 1000))
+   {
+    settings.batcal = BATCAL;
+   }
+
    if(ss) saveSettings();
 }
 

--- a/Arduino/RP2040_OOK48_LCD/config.ino
+++ b/Arduino/RP2040_OOK48_LCD/config.ino
@@ -23,6 +23,7 @@ bool cfgLoop = false;
   {
   drawCFGKbd();
   delay(50); // UI debouncing
+  showVoltage(true);
     while(!done)
     {
 
@@ -50,6 +51,7 @@ bool cfgLoop = false;
             done = true;
           }
         }
+       showVoltage(false);
     }
 
   switch(ch)
@@ -263,4 +265,27 @@ uint16_t cfgTextcolour;
                         CFG_W, CFG_H, TFT_WHITE, TFT_BLUE, TFT_WHITE,
                         congfglabels[12],  CFG_TEXTSIZE);
       cfgKbd[12].drawButton(); 
+}
+
+void showVoltage(bool force)
+{
+  char txt[10];
+  float voltage;
+  static float lastvolt;
+  
+  for(int i=0;i<1024;i++)
+   {
+    voltage = voltage + (float) buffer[bufIndex][i]/620.0;
+   }
+  voltage = voltage / 1024;
+  if((abs(voltage - lastvolt) > 0.01) | (force))
+   {
+     sprintf(txt,"%0.2f V",voltage);
+     tft.setFreeFont(&FreeSans12pt7b);  // Font
+     tft.setTextColor(TFT_CYAN);
+     tft.fillRect(200, 300, 70, 20, TFT_DARKGREY);
+     tft.drawString(txt, 200, 300);
+     lastvolt = voltage;
+   }
+
 }

--- a/Arduino/RP2040_OOK48_LCD/config.ino
+++ b/Arduino/RP2040_OOK48_LCD/config.ino
@@ -23,7 +23,7 @@ bool cfgLoop = false;
   {
   drawCFGKbd();
   delay(50); // UI debouncing
-  showVoltage(true);
+  showVoltage(true,false);
     while(!done)
     {
 
@@ -42,6 +42,11 @@ bool cfgLoop = false;
           }
         }
 
+        if(pressed && t_y > 300 && t_x > 200 && t_x <270)             //touch on voltage display 
+         {
+           showVoltage(true,true);                                    //recalibrate to 4.2V
+         }
+
         // Check if any key has changed state
         for (uint8_t b = 0; b < CFG_NUMBEROFBUTTONS; b++) 
         {
@@ -51,7 +56,7 @@ bool cfgLoop = false;
             done = true;
           }
         }
-       showVoltage(false);
+       showVoltage(false,false);
     }
 
   switch(ch)
@@ -267,7 +272,7 @@ uint16_t cfgTextcolour;
       cfgKbd[12].drawButton(); 
 }
 
-void showVoltage(bool force)
+void showVoltage(bool force,bool cal)
 {
   char txt[10];
   float voltage;
@@ -275,9 +280,14 @@ void showVoltage(bool force)
   
   for(int i=0;i<1024;i++)
    {
-    voltage = voltage + (float) buffer[bufIndex][i]/620.0;
+    voltage = voltage + (float) buffer[bufIndex][i]/settings.batcal;
    }
   voltage = voltage / 1024;
+  if(cal)                                 //if we are calibrating adjust settings.batcal so that the result is 4.20
+   {
+    float error = voltage/4.20;           //calculate the error percentage
+    settings.batcal = settings.batcal * error;
+   }
   if((abs(voltage - lastvolt) > 0.01) | (force))
    {
      sprintf(txt,"%0.2f V",voltage);

--- a/Arduino/RP2040_OOK48_LCD/globals.h
+++ b/Arduino/RP2040_OOK48_LCD/globals.h
@@ -14,6 +14,7 @@ struct eepromstruct
   uint8_t decodeMode;             //allow multiple decode modes
   uint16_t txAdvance;             //Tx timing advance in ms
   uint16_t rxRetard;              //Rx Timing retard in ms
+  float batcal;                   //battery voltage calibration factor
 };
 
 struct eepromstruct settings;


### PR DESCRIPTION
Battery voltage is displayed at the bottom of the config page. 

To calibrate the voltage readout power the module via the USB port and turn off or disconnect the battery.
Select the Config page.
The voltage should read 4.20 V which is the peak charging voltage. 
If adjustment is needed just touch the voltage display area and it will recalibrate to 4.20V . 